### PR TITLE
Updated the Auth header & default API URL

### DIFF
--- a/config.ini-dist
+++ b/config.ini-dist
@@ -1,5 +1,5 @@
 [api]
-url = https://dns.api.gandi.net/api/v5
+url = https://api.gandi.net/v5/livedns/
 ; Generate your Gandi API key via : https://account.gandi.net/en/users/<user>/security
 key =
 

--- a/dyn_gandi.py
+++ b/dyn_gandi.py
@@ -118,7 +118,7 @@ def livedns_handle(domain, ip, records):
     if r_snap is None:
         raise RuntimeWarning("Could not create snapshot." % domain)
 
-    snapshot_uuid = r_snap['uuid']
+    snapshot_uuid = r_snap['id']
 
     if verbose:
         print("Backup snapshot created, uuid: %s." % snapshot_uuid)

--- a/livedns_client.py
+++ b/livedns_client.py
@@ -37,7 +37,7 @@ class LiveDNSClient:
         url = "%s%s" % (self.url, urllib.parse.quote(query))
 
         headers = {
-            "x-api-key":        self.key,
+            "Authorization":    "Apikey %s" % self.key,
             "Accept":           "application/json",
         }
 


### PR DESCRIPTION
Hi,
It seems the HTTP header needed by Gandi changed, as well as the default API URL. Here are the changes I did in order for dyn-gandi to work on my server.