### PR TITLE
Api key deprecation

### DIFF
--- a/config.ini-dist
+++ b/config.ini-dist
@@ -1,6 +1,6 @@
 [api]
 url = https://api.gandi.net/v5/livedns/
-; Generate your Gandi API key via : https://account.gandi.net/en/users/<user>/security
+; Generate your Gandi Personal Access Token via Gandi Dashboard > Organizations > Manage > Create a token
 key =
 
 [dns]

--- a/livedns_client.py
+++ b/livedns_client.py
@@ -38,7 +38,7 @@ class LiveDNSClient:
 
         headers = {
             "x-api-key":        self.key,
-            "Authorization":    "Apikey %s" % self.key,
+            "Authorization":    "Bearer %s" % self.key,
             "Accept":           "application/json",
         }
 


### PR DESCRIPTION
As discussed [here](https://github.com/acmesh-official/acme.sh/issues/4836#issuecomment-1832351969), Gandi has deprecated API keys recently. Because of this, I've made some minor changes so that the LiveDNS client now uses the 'Bearer' authentication header instead of the 'Apikey' header. 