### PR TITLE
feat(dyn-gandi): Handle TXT records

### DIFF
--- a/config.ini-dist
+++ b/config.ini-dist
@@ -9,6 +9,7 @@ key =
 domain =
 ; comma-separated records list
 records = @,www
+txt_records = @
 ttl = 3600
 ; if true, '@' record update will also trigger PTR record update
 update_ptr = false

--- a/dyn_gandi.py
+++ b/dyn_gandi.py
@@ -134,8 +134,19 @@ def livedns_handle(domain, ip, records):
 
     # update DNS records
     for rec in records:
+        r_update = None
+        updated_value = ip
         try:
-            r_update = ldns.put_domain_record(domain=domain, record_name=rec['name'], record_type=rec['type'], value=ip, ttl=int(config['dns']['ttl']))
+            if rec['type'] == "TXT":
+                # Get TXT record remote value
+                r_value = ldns.get_domain_record(domain, record_name=rec['name'], record_type=rec['type'])
+                if not r_value or not r_value.get('values', []):
+                    raise RuntimeWarning("TXT record '%s' not found. Can't proceed with update" % rec['name'])
+
+                # Generate new value
+                updated_value= r_value['values'][0].replace(dns_ip, ip)
+
+            r_update = ldns.put_domain_record(domain=domain, record_name=rec['name'], record_type=rec['type'], value=updated_value, ttl=int(config['dns']['ttl']))
         except Exception as e:
             print(
                 "%s, Error: %s. Backup snapshot id: %s."
@@ -242,6 +253,9 @@ def main():
     records = []
     for rec in config['dns']['records'].split(","):
         records.append({"type": "A", "name": rec})
+
+    for rec in config['dns']['txt_records'].split(","):
+        records.append({"type": "TXT", "name": rec})
 
     if not records:
         raise RuntimeWarning("No records to update, check configuration.")


### PR DESCRIPTION
Hey,

I had this idea to try and fix issue #18.
This is my first contribution on a public repo so I'm open to anything you'd have to say ! 

I tested the code and it works great but I'm kind of worried of how it would react if the "main record" used to get the "dns_ip" variable is not of type "A" (Although I can't think of a use case were you would want to update a TXT record without changing another A record). 
A solution could be to make sure "config['dns']['records']" isn't empty ?

Let me know what you think :) 
